### PR TITLE
EHouseCalc と EProgression に関連する if の連続を switch に書き換え

### DIFF
--- a/microcosmWin/microcosm/MainWindow.xaml.cs
+++ b/microcosmWin/microcosm/MainWindow.xaml.cs
@@ -804,26 +804,16 @@ namespace microcosm
             }
 
 
-            if (currentSetting.houseCalc == EHouseCalc.CAMPANUS)
+            mainWindowVM.houseDivide = currentSetting.houseCalc switch
             {
-                mainWindowVM.houseDivide = "CAMPANUS";
-            }
-            else if (currentSetting.houseCalc == EHouseCalc.EQUAL)
-            {
-                mainWindowVM.houseDivide = "EQUAL";
-            }
-            else if (currentSetting.houseCalc == EHouseCalc.KOCH)
-            {
-                mainWindowVM.houseDivide = "KOCH";
-            }
-            else if (currentSetting.houseCalc == EHouseCalc.PLACIDUS)
-            {
-                mainWindowVM.houseDivide = "PLACIDUS";
-            }
-            else if (currentSetting.houseCalc == EHouseCalc.ZEROARIES)
-            {
-                mainWindowVM.houseDivide = "Zero Aries";
-            }
+                EHouseCalc.PLACIDUS => "PLACIDUS",
+                EHouseCalc.KOCH => "KOCH",
+                EHouseCalc.CAMPANUS => "CAMPANUS",
+                EHouseCalc.EQUAL => "EQUAL",
+                EHouseCalc.ZEROARIES => "Zero Aries",
+                _ => throw new ArgumentOutOfRangeException(nameof(currentSetting.houseCalc)),
+            };
+
             if (configData.centric == ECentric.GEO_CENTRIC)
             {
                 mainWindowVM.centricMode = "GeoCentric";

--- a/microcosmWin/microcosm/MainWindow.xaml.cs
+++ b/microcosmWin/microcosm/MainWindow.xaml.cs
@@ -558,28 +558,14 @@ namespace microcosm
             {
                 // progresはlist1とlist3の時刻で固定
                 list2 = calc.Progress(list1, list1UserData, list3UserData.GetBirthDateTime(), list1UserData.timezone, list1UserData.lat, list1UserData.lng);
-                if (currentSetting.progression == EProgression.SECONDARY)
+                houseList2 = currentSetting.progression switch
                 {
-                    houseList2 = calc.SecondaryProgressionHouseCalc(houseList1, list1, list1UserData.GetBirthDateTime(), list3UserData.GetBirthDateTime(), list1UserData.lat, list1UserData.lng, list1UserData.timezone);
-                }
-                else if (currentSetting.progression == EProgression.PRIMARY)
-                {
-                    houseList2 = calc.PrimaryProgressionHouseCalc(houseList1, list1UserData.GetBirthDateTime(), list3UserData.GetBirthDateTime());
-                }
-                else if (currentSetting.progression == EProgression.SOLAR)
-                {
-                    houseList2 = calc.SolarArcHouseCalc(list1[0].absolute_position, houseList1, list1UserData.GetBirthDateTime(), list3UserData.GetBirthDateTime(), list1UserData.timezone);
-                }
-                else if (currentSetting.progression == EProgression.CPS)
-                {
-                    houseList2 = calc.CompositProgressionHouseCalc( houseList1, list1, list1UserData.GetBirthDateTime(), list3UserData.GetBirthDateTime(), list1UserData.lat, list1UserData.lng, list1UserData.timezone);
-                }
-                else
-                {
-                    houseList2 = calc.CuspCalc(list1UserData.GetBirthDateTime(),
-                            list1UserData.timezone, list3UserData.lat, list3UserData.lng, configData.houseCalc);
-                }
-
+                    EProgression.SECONDARY => calc.SecondaryProgressionHouseCalc(houseList1, list1, list1UserData.GetBirthDateTime(), list3UserData.GetBirthDateTime(), list1UserData.lat, list1UserData.lng, list1UserData.timezone),
+                    EProgression.PRIMARY => calc.PrimaryProgressionHouseCalc(houseList1, list1UserData.GetBirthDateTime(), list3UserData.GetBirthDateTime()),
+                    EProgression.SOLAR => calc.SolarArcHouseCalc(list1[0].absolute_position, houseList1, list1UserData.GetBirthDateTime(), list3UserData.GetBirthDateTime(), list1UserData.timezone),
+                    EProgression.CPS => calc.CompositProgressionHouseCalc(houseList1, list1, list1UserData.GetBirthDateTime(), list3UserData.GetBirthDateTime(), list1UserData.lat, list1UserData.lng, list1UserData.timezone),
+                    _ => calc.CuspCalc(list1UserData.GetBirthDateTime(), list1UserData.timezone, list3UserData.lat, list3UserData.lng, configData.houseCalc),
+                };
                 list2[CommonData.ZODIAC_ASC] = new PlanetData
                 {
                     no = CommonData.ZODIAC_ASC,
@@ -776,23 +762,14 @@ namespace microcosm
             mainWindowVM.targetUser2 = calcTargetUser[1].ToString();
             mainWindowVM.targetUser3 = calcTargetUser[2].ToString();
 
-
-            if (currentSetting.progression == EProgression.SOLAR)
+            mainWindowVM.progressionCalc = currentSetting.progression switch
             {
-                mainWindowVM.progressionCalc = "ソーラーアーク法";
-            }
-            else if (currentSetting.progression == EProgression.SECONDARY)
-            {
-                mainWindowVM.progressionCalc = "一日一年法";
-            }
-            else if (currentSetting.progression == EProgression.PRIMARY)
-            {
-                mainWindowVM.progressionCalc = "一度一年法";
-            }
-            else
-            {
-                mainWindowVM.progressionCalc = "CPS";
-            }
+                EProgression.SOLAR => "ソーラーアーク法",
+                EProgression.SECONDARY => "一日一年法",
+                EProgression.PRIMARY => "一度一年法",
+                EProgression.CPS => "CPS",
+                _ => throw new ArgumentOutOfRangeException(nameof(currentSetting.progression)),
+            };
 
             if (configData.sidereal == Esidereal.SIDEREAL)
             {

--- a/microcosmWin/microcosm/SettingWindow.xaml.cs
+++ b/microcosmWin/microcosm/SettingWindow.xaml.cs
@@ -116,25 +116,19 @@ namespace microcosm
             SaveAspectKindLabel.Content = "";
             SaveOrbsLabel.Content = "";
 
-            if (main.settings[0].houseCalc == config.EHouseCalc.PLACIDUS)
             {
-                placidus.IsChecked = true;
-            }
-            else if (main.settings[0].houseCalc == config.EHouseCalc.KOCH)
-            {
-                koch.IsChecked = true;
-            }
-            else if (main.settings[0].houseCalc == config.EHouseCalc.CAMPANUS)
-            {
-                campanus.IsChecked = true;
-            }
-            else if (main.settings[0].houseCalc == config.EHouseCalc.EQUAL)
-            {
-                equal.IsChecked = true;
-            }
-            else if (main.settings[0].houseCalc == config.EHouseCalc.ZEROARIES)
-            {
-                zeroaries.IsChecked = true;
+                // TODO: そもそも RadioButton の選択を Enum にやらせればこんな分岐は要らないはず
+                var houseCalc = main.settings[0].houseCalc;
+                var target = houseCalc switch
+                {
+                    EHouseCalc.PLACIDUS => placidus,
+                    EHouseCalc.KOCH => koch,
+                    EHouseCalc.CAMPANUS => campanus,
+                    EHouseCalc.EQUAL => equal,
+                    EHouseCalc.ZEROARIES => zeroaries,
+                    _ => throw new ArgumentOutOfRangeException(nameof(houseCalc)),
+                };
+                target.IsChecked = true;
             }
 
             if (main.settings[0].progression == config.EProgression.SECONDARY)
@@ -259,26 +253,21 @@ namespace microcosm
             SaveAspectKindLabel.Content = "";
             SaveOrbsLabel.Content = "";
 
-            if (main.settings[index].houseCalc == config.EHouseCalc.PLACIDUS)
             {
-                placidus.IsChecked = true;
+                // TODO: そもそも RadioButton の選択を Enum にやらせればこんな分岐は要らないはず
+                var houseCalc = main.settings[index].houseCalc;
+                var target = houseCalc switch
+                {
+                    EHouseCalc.PLACIDUS => placidus,
+                    EHouseCalc.KOCH => koch,
+                    EHouseCalc.CAMPANUS => campanus,
+                    EHouseCalc.EQUAL => equal,
+                    EHouseCalc.ZEROARIES => zeroaries,
+                    _ => throw new ArgumentOutOfRangeException(nameof(houseCalc)),
+                };
+                target.IsChecked = true;
             }
-            else if (main.settings[index].houseCalc == config.EHouseCalc.KOCH)
-            {
-                koch.IsChecked = true;
-            }
-            else if (main.settings[index].houseCalc == config.EHouseCalc.CAMPANUS)
-            {
-                campanus.IsChecked = true;
-            }
-            else if (main.settings[index].houseCalc == config.EHouseCalc.EQUAL)
-            {
-                equal.IsChecked = true;
-            }
-            else if (main.settings[index].houseCalc == config.EHouseCalc.ZEROARIES)
-            {
-                zeroaries.IsChecked = true;
-            }
+
 
             if (main.settings[index].progression == config.EProgression.SECONDARY)
             {
@@ -509,6 +498,7 @@ namespace microcosm
                 setting.progression = EProgression.CPS;
             }
 
+            // TODO: そもそも RadioButton の選択を Enum にやらせればこんな分岐は要らないはず
             if (placidus.IsChecked == true)
             {
                 setting.houseCalc = EHouseCalc.PLACIDUS;

--- a/microcosmWin/microcosm/SettingWindow.xaml.cs
+++ b/microcosmWin/microcosm/SettingWindow.xaml.cs
@@ -131,21 +131,18 @@ namespace microcosm
                 target.IsChecked = true;
             }
 
-            if (main.settings[0].progression == config.EProgression.SECONDARY)
             {
-                secondaryProgression.IsChecked = true;
-            }
-            else if (main.settings[0].progression == config.EProgression.PRIMARY)
-            {
-                koch.IsChecked = true;
-            }
-            else if (main.settings[0].progression == config.EProgression.SOLAR)
-            {
-                solarArcProgression.IsChecked = true;
-            }
-            else if (main.settings[0].progression == config.EProgression.CPS)
-            {
-                compositProgression.IsChecked = true;
+                // TODO: そもそも RadioButton の選択を Enum にやらせればこんな分岐は要らないはず
+                var progression = main.settings[0].progression;
+                var target = progression switch
+                {
+                    EProgression.SECONDARY => secondaryProgression,
+                    EProgression.PRIMARY => primaryProgression,
+                    EProgression.SOLAR => solarArcProgression,
+                    EProgression.CPS => compositProgression,
+                    _ => throw new ArgumentOutOfRangeException(nameof(progression)),
+                };
+                target.IsChecked = true;
             }
 
             if (main.settings[0].sameCusps)
@@ -268,22 +265,18 @@ namespace microcosm
                 target.IsChecked = true;
             }
 
-
-            if (main.settings[index].progression == config.EProgression.SECONDARY)
             {
-                secondaryProgression.IsChecked = true;
-            }
-            else if (main.settings[index].progression == config.EProgression.PRIMARY)
-            {
-                primaryProgression.IsChecked = true;
-            }
-            else if (main.settings[index].progression == config.EProgression.SOLAR)
-            {
-                solarArcProgression.IsChecked = true;
-            }
-            else if (main.settings[index].progression == config.EProgression.CPS)
-            {
-                compositProgression.IsChecked = true;
+                // TODO: そもそも RadioButton の選択を Enum にやらせればこんな分岐は要らないはず
+                var progression = main.settings[index].progression;
+                var target = progression switch
+                {
+                    EProgression.SECONDARY => secondaryProgression,
+                    EProgression.PRIMARY => primaryProgression,
+                    EProgression.SOLAR => solarArcProgression,
+                    EProgression.CPS => compositProgression,
+                    _ => throw new ArgumentOutOfRangeException(nameof(progression)),
+                };
+                target.IsChecked = true;
             }
 
             if (main.settings[index].sameCusps)

--- a/microcosmWin/microcosm/calc/AstroCalc.cs
+++ b/microcosmWin/microcosm/calc/AstroCalc.cs
@@ -457,31 +457,16 @@ namespace microcosm.calc
             double[] cusps = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
             double[] ascmc = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 
-            if (houseKind == EHouseCalc.PLACIDUS)
+            var hsys = houseKind switch
             {
-                // Placidas
-                s.swe_houses(dret[1], lat, lng, 'P', cusps, ascmc);
-            }
-            else if (houseKind == EHouseCalc.KOCH)
-            {
-                // Koch
-                s.swe_houses(dret[1], lat, lng, 'K', cusps, ascmc);
-            }
-            else if (houseKind == EHouseCalc.CAMPANUS)
-            {
-                // Campanus
-                s.swe_houses(dret[1], lat, lng, 'C', cusps, ascmc);
-            }
-            else if (houseKind == EHouseCalc.EQUAL)
-            {
-                // Equal
-                s.swe_houses(dret[1], lat, lng, 'E', cusps, ascmc);
-            }
-            else
-            {
-                // Zero Aries
-                s.swe_houses(dret[1], lat, lng, 'N', cusps, ascmc);
-            }
+                EHouseCalc.PLACIDUS => 'P',
+                EHouseCalc.KOCH => 'K',
+                EHouseCalc.CAMPANUS => 'C',
+                EHouseCalc.EQUAL => 'E',
+                EHouseCalc.ZEROARIES => 'N',
+                _ => throw new ArgumentOutOfRangeException(nameof(houseKind)),
+            };
+            s.swe_houses(dret[1], lat, lng, hsys, cusps, ascmc);
             s.swe_close();
 
             return cusps;

--- a/microcosmWin/microcosm/calc/AstroCalc.cs
+++ b/microcosmWin/microcosm/calc/AstroCalc.cs
@@ -1005,29 +1005,14 @@ namespace microcosm.calc
 
         public Dictionary<int, PlanetData> Progress(Dictionary<int, PlanetData> list1, UserData udata, DateTime transitDate, double timezone, double lat, double lng)
         {
-            Dictionary<int, PlanetData> p;
-            if (currentSetting.progression == EProgression.SOLAR)
+            return currentSetting.progression switch
             {
-                p = SolarArcCalc(list1, udata.GetBirthDateTime(), transitDate, timezone);
-            }
-            else if (currentSetting.progression == EProgression.SECONDARY)
-            {
-                p = SecondaryProgressionCalc(list1, udata.GetBirthDateTime(), transitDate, timezone, lat, lng);
-            }
-            else if (currentSetting.progression == EProgression.PRIMARY)
-            {
-                p = PrimaryProgressionCalc(list1, udata.GetBirthDateTime(), transitDate);
-            }
-            else if (currentSetting.progression == EProgression.CPS)
-            {
-                p = CompositProgressionCalc(list1, udata.GetBirthDateTime(), transitDate, timezone);
-            }
-            else
-            {
-                p = PositionCalc(transitDate, udata.lat, udata.lng, configData.houseCalc, 1);
-            }
-
-            return p;
+                EProgression.SOLAR => SolarArcCalc(list1, udata.GetBirthDateTime(), transitDate, timezone),
+                EProgression.SECONDARY => SecondaryProgressionCalc(list1, udata.GetBirthDateTime(), transitDate, timezone, lat, lng),
+                EProgression.PRIMARY => PrimaryProgressionCalc(list1, udata.GetBirthDateTime(), transitDate),
+                EProgression.CPS => CompositProgressionCalc(list1, udata.GetBirthDateTime(), transitDate, timezone),
+                _ => PositionCalc(transitDate, udata.lat, udata.lng, configData.houseCalc, 1), // Unreachable?
+            };
         }
 
         public Dictionary<int, PlanetData> DraconicPositionCalc(DateTime d, double lat, double lng, EHouseCalc houseKind, int subIndex)


### PR DESCRIPTION
## 関連する Issue
#2 (部分的解決)

## PR の概要
if をたくさんつかって enum の値で分岐しているものを switch 式に書き換え。
RadioButton の状態を更新する処理については、そもそもどの RadioButton を Checked にするかを Enum の状態として持てばよいはずなので、別の PR で対応した方がよさそう。

## 参考資料
[公式の if-else と switch の解説](https://learn.microsoft.com/ja-jp/dotnet/csharp/language-reference/statements/selection-statements)
[switch 文 (switch ステートメント) と switch 式 の解説](https://ufcpp.net/blog/2018/12/cs8switchexpr/)